### PR TITLE
Fixed #15: Inline defs are now inlined

### DIFF
--- a/ultraviolet/shared/src/main/scala/ultraviolet/macros/CreateShaderAST.scala
+++ b/ultraviolet/shared/src/main/scala/ultraviolet/macros/CreateShaderAST.scala
@@ -1190,6 +1190,14 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
           None
         )
 
+      // Swizzle a function call
+      case Select(term @ Apply(Ident(_), _), swzl) if isSwizzle.matches(swzl) =>
+        ShaderAST.DataTypes.swizzle(
+          walkTerm(term, envVarName),
+          swzl,
+          None
+        )
+
       // Inlined external def
 
       case Inlined(Some(Apply(Ident(name), args)), ds, x @ Typed(term, typeTree)) =>

--- a/ultraviolet/shared/src/main/scala/ultraviolet/macros/ProxyManager.scala
+++ b/ultraviolet/shared/src/main/scala/ultraviolet/macros/ProxyManager.scala
@@ -38,6 +38,13 @@ final class ProxyManager:
   def add(name: String, proxy: Proxy): Unit =
     proxyLookUp += name -> proxy
 
+  private val proxyInlineReplace: HashMap[String, ShaderAST] = new HashMap()
+
+  def addInlineReplace(id: String, value: ShaderAST): Unit =
+    proxyInlineReplace += id -> value
+  def lookUpInlineReplace(id: String): Option[ShaderAST] =
+    proxyInlineReplace.get(id)
+
 final case class Proxy(name: String, argType: List[ShaderAST], returnType: Option[ShaderAST])
 object Proxy:
   def apply(name: String): Proxy = Proxy(name, Nil, None)

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
@@ -271,7 +271,7 @@ class GLSLExternalTests extends munit.FunSuite {
     assertEquals(
       actual,
       s"""
-      |vec2 def0(in int _fillType,in vec4 _fallback,in sampler2D _srcChannel,in vec2 _channelPos,in vec2 _channelSize,in vec2 _uv,in vec2 _entitySize){
+      |vec4 def0(in int _fillType,in vec4 _fallback,in sampler2D _srcChannel,in vec2 _channelPos,in vec2 _channelSize,in vec2 _uv,in vec2 _entitySize,in vec2 _textureSize){
       |  return switch(_fillType){
       |    case 1:
       |      texture(_srcChannel,_channelPos+(_uv*_channelSize));

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
@@ -243,7 +243,7 @@ class GLSLExternalTests extends munit.FunSuite {
 
         val fillType: Int              = 0
         val fallback: vec4             = vec4(1.0)
-        val srcChannel: sampler2D.type = sampler2D
+        @uniform val srcChannel: sampler2D.type = sampler2D
         val channelPos: vec2           = vec2(2.0)
         val channelSize: vec2          = vec2(3.0)
         val uv: vec2                   = vec2(4.0)
@@ -272,21 +272,23 @@ class GLSLExternalTests extends munit.FunSuite {
       actual,
       s"""
       |vec4 def0(in int _fillType,in vec4 _fallback,in sampler2D _srcChannel,in vec2 _channelPos,in vec2 _channelSize,in vec2 _uv,in vec2 _entitySize,in vec2 _textureSize){
-      |  return switch(_fillType){
+      |  vec4 val0;
+      |  switch(_fillType){
       |    case 1:
-      |      texture(_srcChannel,_channelPos+(_uv*_channelSize));
+      |      val0=texture(_srcChannel,_channelPos+(_uv*_channelSize));
       |      break;
       |    case 2:
-      |      texture(_srcChannel,_channelPos+((fract(_uv*(_entitySize/_textureSize)))*_channelSize));
+      |      val0=texture(_srcChannel,_channelPos+((fract(_uv*(_entitySize/_textureSize)))*_channelSize));
       |      break;
       |    default:
-      |      _fallback;
+      |      val0=_fallback;
       |      break;
       |  }
+      |  return val0;
       |}
       |int fillType=0;
       |vec4 fallback=vec4(1.0);
-      |sampler2D srcChannel=sampler2D;
+      |uniform sampler2D srcChannel;
       |vec2 channelPos=vec2(2.0);
       |vec2 channelSize=vec2(3.0);
       |vec2 uv=vec2(4.0);

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
@@ -101,4 +101,262 @@ class GLSLExternalTests extends munit.FunSuite {
     )
   }
 
+  test("should correctly render tile code") {
+
+    inline def fragment =
+      Shader {
+        import TileAndStretch.*
+
+        val uv: vec2          = vec2(1.0)
+        val channelPos: vec2  = vec2(2.0)
+        val channelSize: vec2 = vec2(3.0)
+        val entitySize: vec2  = vec2(4.0)
+        val textureSize: vec2 = vec2(5.0)
+
+        tiledUVs(
+          uv,          // env.UV,
+          channelPos,  // env.CHANNEL_0_POSITION,
+          channelSize, // env.CHANNEL_0_SIZE,
+          entitySize,  // env.SIZE,
+          textureSize  // env.TEXTURE_SIZE
+        )
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].code
+
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |vec2 uv=vec2(1.0);
+      |vec2 channelPos=vec2(2.0);
+      |vec2 channelSize=vec2(3.0);
+      |vec2 entitySize=vec2(4.0);
+      |vec2 textureSize=vec2(5.0);
+      |channelPos+((fract(uv*(entitySize/textureSize)))*channelSize);
+      |""".stripMargin.trim
+    )
+
+  }
+
+  test("should correctly render stretch code") {
+
+    inline def fragment =
+      Shader {
+        import TileAndStretch.*
+
+        val uv: vec2          = vec2(1.0)
+        val channelPos: vec2  = vec2(2.0)
+        val channelSize: vec2 = vec2(3.0)
+
+        stretchedUVs(
+          uv,         // env.UV,
+          channelPos, // env.CHANNEL_0_POSITION,
+          channelSize // env.CHANNEL_0_SIZE,
+        )
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].code
+
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |vec2 uv=vec2(1.0);
+      |vec2 channelPos=vec2(2.0);
+      |vec2 channelSize=vec2(3.0);
+      |channelPos+(uv*channelSize);
+      |""".stripMargin.trim
+    )
+
+  }
+
+  test("should correctly render tile and stretch code (def)") {
+
+    inline def fragment =
+      Shader {
+        import TileAndStretch.*
+
+        val fillType: Int              = 0
+        val fallback: vec4             = vec4(1.0)
+        val srcChannel: sampler2D.type = sampler2D
+        val channelPos: vec2           = vec2(2.0)
+        val channelSize: vec2          = vec2(3.0)
+        val uv: vec2                   = vec2(4.0)
+        val entitySize: vec2           = vec2(5.0)
+        val textureSize: vec2          = vec2(6.0)
+
+        tileAndStretchChannelDef(
+          fillType,    // env.FILLTYPE.toInt,
+          fallback,    // env.CHANNEL_0,
+          srcChannel,  // env.SRC_CHANNEL,
+          channelPos,  // env.CHANNEL_0_POSITION,
+          channelSize, // env.CHANNEL_0_SIZE,
+          uv,          // env.UV,
+          entitySize,  // env.SIZE,
+          textureSize  // env.TEXTURE_SIZE
+        )
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |int fillType=0;
+      |vec4 fallback=vec4(1.0);
+      |sampler2D srcChannel=sampler2D;
+      |vec2 channelPos=vec2(2.0);
+      |vec2 channelSize=vec2(3.0);
+      |vec2 uv=vec2(4.0);
+      |vec2 entitySize=vec2(5.0);
+      |vec2 textureSize=vec2(6.0);
+      |switch(fillType){
+      |  case 1:
+      |    texture(srcChannel,channelPos+(uv*channelSize));
+      |    break;
+      |  case 2:
+      |    texture(srcChannel,channelPos+((fract(uv*(entitySize/textureSize)))*channelSize));
+      |    break;
+      |  default:
+      |    fallback;
+      |    break;
+      |}
+      |""".stripMargin.trim
+    )
+
+  }
+
+  test("should correctly render tile and stretch code (fn)") {
+
+    inline def fragment =
+      Shader {
+        import TileAndStretch.*
+
+        val fillType: Int              = 0
+        val fallback: vec4             = vec4(1.0)
+        val srcChannel: sampler2D.type = sampler2D
+        val channelPos: vec2           = vec2(2.0)
+        val channelSize: vec2          = vec2(3.0)
+        val uv: vec2                   = vec2(4.0)
+        val entitySize: vec2           = vec2(5.0)
+        val textureSize: vec2          = vec2(6.0)
+
+        tileAndStretchChannelFn(
+          fillType,    // env.FILLTYPE.toInt,
+          fallback,    // env.CHANNEL_0,
+          srcChannel,  // env.SRC_CHANNEL,
+          channelPos,  // env.CHANNEL_0_POSITION,
+          channelSize, // env.CHANNEL_0_SIZE,
+          uv,          // env.UV,
+          entitySize,  // env.SIZE,
+          textureSize  // env.TEXTURE_SIZE
+        )
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |vec2 def0(in int _fillType,in vec4 _fallback,in sampler2D _srcChannel,in vec2 _channelPos,in vec2 _channelSize,in vec2 _uv,in vec2 _entitySize){
+      |  return switch(_fillType){
+      |    case 1:
+      |      texture(_srcChannel,_channelPos+(_uv*_channelSize));
+      |      break;
+      |    case 2:
+      |      texture(_srcChannel,_channelPos+((fract(_uv*(_entitySize/_textureSize)))*_channelSize));
+      |      break;
+      |    default:
+      |      _fallback;
+      |      break;
+      |  }
+      |}
+      |int fillType=0;
+      |vec4 fallback=vec4(1.0);
+      |sampler2D srcChannel=sampler2D;
+      |vec2 channelPos=vec2(2.0);
+      |vec2 channelSize=vec2(3.0);
+      |vec2 uv=vec2(4.0);
+      |vec2 entitySize=vec2(5.0);
+      |vec2 textureSize=vec2(6.0);
+      |def0(fillType,fallback,srcChannel,channelPos,channelSize,uv,entitySize,textureSize);
+      |""".stripMargin.trim
+    )
+
+  }
+
 }
+
+object TileAndStretch:
+
+  inline def stretchedUVs(uv: vec2, channelPos: vec2, channelSize: vec2): vec2 =
+    channelPos + uv * channelSize
+
+  inline def tiledUVs(uv: vec2, channelPos: vec2, channelSize: vec2, entitySize: vec2, textureSize: vec2): vec2 =
+    channelPos + (fract(uv * (entitySize / textureSize)) * channelSize)
+
+  inline def tileAndStretchChannelDef(
+      _fillType: Int,
+      _fallback: vec4,
+      _srcChannel: sampler2D.type,
+      _channelPos: vec2,
+      _channelSize: vec2,
+      _uv: vec2,
+      _entitySize: vec2,
+      _textureSize: vec2
+  ): vec4 =
+    _fillType match
+      case 1 =>
+        texture2D(
+          _srcChannel,
+          stretchedUVs(_uv, _channelPos, _channelSize)
+        )
+
+      case 2 =>
+        texture2D(
+          _srcChannel,
+          tiledUVs(_uv, _channelPos, _channelSize, _entitySize, _textureSize)
+        )
+
+      case _ =>
+        _fallback
+
+  inline def tileAndStretchChannelFn =
+    (
+        _fillType: Int,
+        _fallback: vec4,
+        _srcChannel: sampler2D.type,
+        _channelPos: vec2,
+        _channelSize: vec2,
+        _uv: vec2,
+        _entitySize: vec2,
+        _textureSize: vec2
+    ) =>
+      _fillType match
+        case 1 =>
+          texture2D(
+            _srcChannel,
+            stretchedUVs(_uv, _channelPos, _channelSize)
+          )
+
+        case 2 =>
+          texture2D(
+            _srcChannel,
+            tiledUVs(_uv, _channelPos, _channelSize, _entitySize, _textureSize)
+          )
+
+        case _ =>
+          _fallback

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLExternalTests.scala
@@ -64,13 +64,10 @@ class GLSLExternalTests extends munit.FunSuite {
     assertEquals(
       actual,
       s"""
-      |vec2 fn1(in float val0){
-      |  return vec2(1.0);
-      |}
       |vec2 def0(in float alpha){
       |  return vec2(0.0,alpha);
       |}
-      |vec4(fn1(1.0),def0(1.0));
+      |vec4(vec2(1.0),def0(1.0));
       |""".stripMargin.trim
     )
   }
@@ -96,13 +93,10 @@ class GLSLExternalTests extends munit.FunSuite {
     assertEquals(
       actual,
       s"""
-      |vec2 fn1(in float val0,in float val1){
-      |  return vec2(1.0,0.25);
-      |}
       |vec2 def0(in float blue,in float alpha){
       |  return vec2(blue,alpha);
       |}
-      |vec4(fn1(1.0,0.25),def0(0.5,1.0));
+      |vec4(vec2(1.0,0.25),def0(0.5,1.0));
       |""".stripMargin.trim
     )
   }

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLIfStatementTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLIfStatementTests.scala
@@ -292,4 +292,51 @@ class GLSLIfStatementTests extends munit.FunSuite {
     )
   }
 
+  test("nested if else statements can return") {
+    inline def fragment: Shader[FragEnv, vec4] =
+      Shader { _ =>
+        val red    = vec4(1.0, 0.0, 0.0, 1.0)
+        val green  = vec4(0.0, 1.0, 0.0, 1.0)
+        val blue   = vec4(0.0, 0.0, 1.0, 1.0)
+        val x: Int = 1
+
+        val color =
+          if x <= 0 then red
+          else {
+            val y = 10
+            if x == 1 && y == 10 then blue
+            else green
+          }
+        color
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |vec4 red=vec4(1.0,0.0,0.0,1.0);
+      |vec4 green=vec4(0.0,1.0,0.0,1.0);
+      |vec4 blue=vec4(0.0,0.0,1.0,1.0);
+      |int x=1;
+      |vec4 color;
+      |if(x<=0){
+      |  color=red;
+      |}else{
+      |  int y=10;
+      |  if((x==1)&&(y==10)){
+      |    color=blue;
+      |  }else{
+      |    color=green;
+      |  }
+      |}
+      |color;
+      |""".stripMargin.trim
+    )
+  }
+
 }

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLImportsTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLImportsTests.scala
@@ -13,7 +13,9 @@ class GLSLImportsTests extends munit.FunSuite {
 
     inline def fragment: Shader[FragEnv, Int] =
       Shader { _ =>
-        addOne(10)
+        val value = 10
+        addOneAnon(value)
+        addOneInline(value)
       }
 
     val actual =
@@ -25,10 +27,12 @@ class GLSLImportsTests extends munit.FunSuite {
     assertEquals(
       actual,
       s"""
-      |int addOne(in int val0){
-      |  return 11;
+      |int def0(in int i){
+      |  return i+1;
       |}
-      |addOne(10);
+      |int value=10;
+      |def0(value);
+      |value+1;
       |""".stripMargin.trim
     )
   }
@@ -37,4 +41,5 @@ class GLSLImportsTests extends munit.FunSuite {
 
 object Importable:
 
-  inline def addOne(i: Int): Int = i + 1
+  inline def addOneAnon = (i: Int) => i + 1
+  inline def addOneInline(i: Int): Int = i + 1


### PR DESCRIPTION
This fixes an old issue where I was attempting to re-construct inline defs and failing, now we just inline the values.

Before this PR is ready to close, I need to check the behaviour of the tile and stretch functions in Indigo to see if they do the right thing now.