### PR TITLE
Fixed #91: If statements can be assigned to vars

### DIFF
--- a/ultraviolet/shared/src/main/scala/ultraviolet/macros/CreateShaderAST.scala
+++ b/ultraviolet/shared/src/main/scala/ultraviolet/macros/CreateShaderAST.scala
@@ -1579,10 +1579,15 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
         throw new ShaderError.Unsupported("Shaders do not support calls to super.")
 
       case Assign(lhs, rhs) =>
-        ShaderAST.Assign(
-          walkTerm(lhs, envVarName),
-          walkTerm(rhs, envVarName)
-        )
+        val l = walkTerm(lhs, envVarName)
+        val r = walkTerm(rhs, envVarName)
+
+        (l, r) match
+          case (i @ ShaderAST.DataTypes.ident(_), f @ ShaderAST.If(_, _, Some(_))) =>
+            recursivelyAssignIf(i, f)
+
+          case (_, _) =>
+            ShaderAST.Assign(l, r)
 
       case If(condTerm, thenTerm, elseTerm) =>
         walkTerm(elseTerm, envVarName) match

--- a/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLIfStatementTests.scala
+++ b/ultraviolet/shared/src/test/scala/ultraviolet/acceptance/GLSLIfStatementTests.scala
@@ -397,4 +397,37 @@ class GLSLIfStatementTests extends munit.FunSuite {
     )
   }
 
+  test("If statements can return and assign to var's") {
+
+    @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.null"))
+    inline def fragment: Shader[FragEnv, vec4] =
+      Shader { _ =>
+        val x0       = vec2(1.0f, 2.0f)
+        var i1: vec2 = null
+        i1 = if x0.x > x0.y then vec2(1.0, 0.0) else vec2(0.0, 1.0)
+
+        vec4(i1, 0.0f, 1.0f)
+      }
+
+    val actual =
+      fragment.toGLSL[WebGL2].toOutput.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertEquals(
+      actual,
+      s"""
+      |vec2 x0=vec2(1.0,2.0);
+      |vec2 i1;
+      |if(x0.x>x0.y){
+      |  i1=vec2(1.0,0.0);
+      |}else{
+      |  i1=vec2(0.0,1.0);
+      |}
+      |vec4(i1,0.0,1.0);
+      |""".stripMargin.trim
+    )
+  }
+
 }


### PR DESCRIPTION
Relates to: https://github.com/PurpleKingdomGames/ultraviolet/issues/91

This code:

```scala
var i1: vec2 = null
i1 = if x0.x > x0.y then vec2(1.0, 0.0) else vec2(0.0, 1.0)
```

Was producing this invalid GLSL:

```glsl
vec2 x0=vec2(1.0,2.0);
vec2 i1;
i1=if(x0.x>x0.y){  vec2(1.0,0.0)}else{  vec2(0.0,1.0)}
vec4(i1,0.0,1.0);
```

Instead of this valid GLSL:

```glsl
vec2 x0=vec2(1.0,2.0);
vec2 i1;
if(x0.x>x0.y){
  i1=vec2(1.0,0.0);
}else{
  i1=vec2(0.0,1.0);
}
vec4(i1,0.0,1.0);
```